### PR TITLE
Re-word sections regarding puisne committee members

### DIFF
--- a/constitution.md
+++ b/constitution.md
@@ -181,7 +181,7 @@ the membership shall consider at a General Meeting whether that person's members
 
 12.4 A special meeting of the management committee shall be convened by the Secretary on the requisition in writing signed by not less than one-third (1/3) of the members of the management committee, which requisition shall clearly state the reasons why such special meeting is being convened and the nature of the business to be transacted thereat.
 
-12.5 A meeting of the Management Committee shall be quorate if both half (1/2) or more of the Officers of Management Committee as at the close of the last General Meeting are present and more than half (1/2) of the Officers of Management Committee as at the close of the last General Meeting and the General Members currently on the Management Committee combined are present.
+12.5 A meeting of the Management Committee shall be quorate if both half (1/2) or more of the Officers of Management Committee as at the close of the last General Meeting are present, and half (1/2) or more of the total number of all members of the Management Committee are present.
 
 12.6 Questions, matters or resolutions arising at any meeting of the Management Committee shall be decided by a vote, and shall pass with a simple majority.
 

--- a/constitution.md
+++ b/constitution.md
@@ -79,19 +79,17 @@ the management committee shall consider whether the member's membership shall be
 ## 7 Membership of Management Committee
 
 7.1 The Management Committee of the Society shall consist of:  
-* a President, Secretary, and Treasurer, all of whom shall be students of the University of Queensland, and all of whom shall be Offices of the Management Committee;  
+* a President, Secretary, and Treasurer, all of whom shall be students of the University of Queensland, and all of whom shall be Officers of the Management Committee;  
 * zero (0) or more other Officers of the Management Committee; and  
-* zero (0) or more Puisne Members of the Management Committee.
+* zero (0) or more General Members of the Management Committee.
 
 7.2 All the aforestated members of the Management Committee must be members of the Society. Membership of the Management Committee shall not be otherwise restricted.
 
 7.3 Each Officer of the Management Committee shall be one (1) member of the society.
 
-7.4 The Puisne Members of the Management Committee shall be shared among several members of the Society.
+7.4 No member may hold more than a single position on the Management Committee.
 
-7.5 No member may hold more than a single position on the Management Committee.
-
-7.6 The number of members of the Management Committee must be less than half (1/2) the number of members that were necessary to constitute quorum at the most recent opening of an annual general meeting.
+7.5 The number of members of the Management Committee must be less than half (1/2) the number of members that were necessary to constitute quorum at the most recent opening of an annual general meeting.
 
 ## 8 Election of Members to the Management Committee
 
@@ -101,24 +99,24 @@ the management committee shall consider whether the member's membership shall be
 
 8.3 At the Annual General Meeting of the Society, all Officer positions other than President, Secretary, and Treasurer are dissolved, but may be re-created.
 
-8.4 At any General Meeting of the Society, the Members of the Society may resolve to create zero (0) or more of Officers of the Management Committee.
+8.4 At any General Meeting of the Society, the Members of the Society may resolve to create zero (0) or more new positions for Officers of the Management Committee.
 
-8.5 At any General Meeting of the Society, the Members of the Society may resolve to create zero (0) or more of Puisne Members of the Management Committee. Except at the Annual General Meeting, all existing Puisne Members shall continue to be members of the Management Committee.
+8.5 At any General Meeting of the Society, the Members of the Society may resolve to create zero (0) or more new positions for General Members of the Management Committee. Except at the Annual General Meeting, all existing General Members of the Management Committee shall continue to be members of the Management Committee
 
 8.6 Voting for each position on the Management Committee will take place in series, with the results for each position announced before voting for the next position. The order of voting for positions on the Management Committee shall be:  
 * the President;  
 * the Secretary;  
 * the Treasurer;  
 * any other Officers of the Management Committee, in the order of creation or re-creation;  
-* the Puisne Members of the Management Committee.
+* all General Members of the Management Committee.
 
-8.7 The election of Officers and Puisne Members of the Management Committee at a General Meeting shall take place in the following manner:  
-* any two (2) members of the Society shall be at liberty to nominate any member of the Society to serve as an Officer or Puisne Member of the Management Committee;  
+8.7 The election of Officers and General Members of the Management Committee at a General Meeting shall take place in the following manner:  
+* any two (2) members of the Society shall be at liberty to nominate any member of the Society to serve as an Officer or General Member of the Management Committee;  
 * the nomination, which shall be in writing, shall be lodged with the Secretary before or at the General Meeting at which the election is to take place;  
 * at the commencement of the General Meeting, any nominations from the floor will be accepted;  
 * if in any election the number of candidates nominated for a position is fewer than or equal to the number of vacancies for that position, those candidates shall be elected unopposed without putting the matter to a vote;  
 * balloting lists shall be prepared (if necessary) containing the names of candidates in the order their nomination was received;  
-* all Officers shall be determined by optional preferential voting and all Puisne Members shall be determined collectively by optional preferential proportional representation voting;  
+* all Officers shall be determined by optional preferential voting and all General Members shall be determined collectively by optional preferential proportional representation voting;  
 * the vote of every member of the Society shall be of equal weight;  
 * all elections must be by secret ballot;  
 * the assembly will select an impartial Returning Officer, who shall be responsible for ensuring the orderly running of the election;  
@@ -128,12 +126,12 @@ the management committee shall consider whether the member's membership shall be
 * in the case of a third tie between the same candidates, the winner shall be determined by sortition; and  
 * any informality or irregularity with the elections must be brought to the attention of the Clubs and Societies Administration Officer within fourteen (14) days of the election.
 
-8.8 The election of Puisne Members of the Management Committee without a General Meeting shall take place in the following manner:  
-* the Management Committee shall be at liberty to nominate any member of the Society to serve as a Puisne Member of the Management Committee;  
+8.8 The election of General Members of the Management Committee without a General Meeting shall take place in the following manner:  
+* the Management Committee shall be at liberty to nominate any member of the Society to serve as a General Member of the Management Committee;  
 * the Management Committee must give every member of the Society an opportunity to vote secretly and securely;  
 * the members of the Society shall have no less than seven (7) days to cast their vote;  
 * the vote of every member of the Society shall be of equal weight;  
-* the nominee will be elected as a Puisne Member of the Management Committee if and only if the number of votes of the members of the Society in favour equals or exceeds the number of members of the Society needed to constitute quorum of a General Meeting of the Society and the number of votes of the members of the Society in favour equals or exceeds twice the number of votes of the members of the Society against.  
+* the nominee will be elected as a General Member of the Management Committee if and only if the number of votes of the members of the Society in favour equals or exceeds the number of members of the Society needed to constitute quorum of a General Meeting of the Society and the number of votes of the members of the Society in favour equals or exceeds twice the number of votes of the members of the Society against.  
 * any informality or irregularity with the elections must be brought to the attention of the Clubs and Societies Administration Officer within fourteen (14) days of the election.
 
 ## 9 Resignation or Removal from Office of Membership of Management Committee
@@ -160,7 +158,7 @@ the membership shall consider at a General Meeting whether that person's members
 
 10.2 The continuing members of the Management Committee may act notwithstanding any casual vacancy in the Management Committee, but if their number is reduced below the number fixed as necessary for quorum of the Management Committee, the continuing members may act for the purpose of increasing the number of members of the Management Committee to that number required to achieve quorum or by summoning a General Meeting of the Society, but for no other purpose.
 
-10.3 The resignation or removal of a Puisne Member does not create a casual vacancy on the Management Committee.
+10.3 The resignation or removal of a General Member from the Management Committee does not create a casual vacancy.
 
 ## 11 Functions of the Management Committee
 
@@ -183,7 +181,7 @@ the membership shall consider at a General Meeting whether that person's members
 
 12.4 A special meeting of the management committee shall be convened by the Secretary on the requisition in writing signed by not less than one-third (1/3) of the members of the management committee, which requisition shall clearly state the reasons why such special meeting is being convened and the nature of the business to be transacted thereat.
 
-12.5 A meeting of the Management Committee shall be quorate if both half (1/2) or more of the Officers of Management Committee as at the close of the last General Meeting are present and more than half (1/2) of the Officers of Management Committee as at the close of the last General Meeting and the Puisne Members currently on the Management Committee combined are present.
+12.5 A meeting of the Management Committee shall be quorate if both half (1/2) or more of the Officers of Management Committee as at the close of the last General Meeting are present and more than half (1/2) of the Officers of Management Committee as at the close of the last General Meeting and the General Members currently on the Management Committee combined are present.
 
 12.6 Questions, matters or resolutions arising at any meeting of the Management Committee shall be decided by a vote, and shall pass with a simple majority.
 


### PR DESCRIPTION
I am not necessarily attached to the term "General Member of the Management Committee", and am open to other suggestions for a suitable wording change.

The term "Puisne" and other removed/updated section on this topic are a potential source of confusion for members reading the constitution. For example, (former) section 7.4 is redundant considering there are multiple Puisne Members, and only adds confusion as to their duties and role within the management committee. This change aims to clarify the general purpose of the Puisne Members of the Management Committee, such that a layman reading the constitution or attending a General Meeting will better understand the purpose of the Puisne Members.

Finally, I will note that the term "Puisne" is already considered obsolete in many jurisdictions.