### PR TITLE
Add meeting attendence requirement for active committee members.

### DIFF
--- a/constitution.md
+++ b/constitution.md
@@ -150,7 +150,9 @@ the membership shall consider at a General Meeting whether that person's members
 
 9.4 That person concerned shall be given a full and fair opportunity to explain matters at the General Meeting. The question of removal shall be determined by a vote of sixty percent (60%) majority of the members present at the General Meeting and must be endorsed by the Clubs and Societies committee.
 
-9.5 There is no right of appeal against a member's removal from the Management Committee under this section.
+9.5 If a member of the Management Committee fails to attend any meetings of the Management Committee for three (3) consecutive calendar months in which at least one (1) meeting was held in each calendar month, that person's membership of the Management Committee shall be terminated.
+
+9.6 There is no right of appeal against a member's removal from the Management Committee under this section.
 
 ## 10 Vacancies on Management Committee
 

--- a/constitution.md
+++ b/constitution.md
@@ -150,7 +150,7 @@ the membership shall consider at a General Meeting whether that person's members
 
 9.4 That person concerned shall be given a full and fair opportunity to explain matters at the General Meeting. The question of removal shall be determined by a vote of sixty percent (60%) majority of the members present at the General Meeting and must be endorsed by the Clubs and Societies committee.
 
-9.5 If a member of the Management Committee fails to attend any meetings of the Management Committee for three (3) consecutive calendar months in which at least one (1) meeting was held in each calendar month, that person's membership of the Management Committee shall be terminated.
+9.5 If a member of the Management Committee fails to attend any meetings of the Management Committee for three (3) consecutive calendar months in which at least one (1) quorate meeting was held in each calendar month, that person's membership of the Management Committee shall be terminated.
 
 9.6 There is no right of appeal against a member's removal from the Management Committee under this section.
 


### PR DESCRIPTION
Throughout the years, dating back to at least when I was on committee, and almost certainly before that, there have been perennial absentee members of committee. It has rarely, if ever, affected the major officers (president, secretary, treasurer), since the sorts of people who nominate for those roles are not the sort of people prone to go missing. It has affected the puisne/general members, but the fungible nature of the puisne/general members means that one absentee member does not disrupt the running of the society.
As of last year's AGM, however, minor officer roles have been elected for the first time since 2016 (vice-president). As such, this opens up a vulnerability in the committee structure. Minor officers are generally more likely to disappear than major officers, and have a greater effect if they do than puisne/general members.
This change will automatically remove any committee member who doesn't attend a committee meeting for three months. This should not be seen as the minimum standard for committee members. Anybody who is removed by this clause should have either resigned or have been removed via the previous clause long before this clause can come into affect. This amendment serves only as a safety valve for when either alternative fails.
Removing an officer will create a casual vacancy on the committee. This will not reduce the number of committee members requires to constitute quorum. The committee is responsible for filling the casual vacancy, either via a motion at a committee meeting, or by calling a SGM, depending on the circumstances.
Removing a general member will not create a casual vacancy on the committee. This will reduce the number of committee members requires to constitute quorum. If the committee so desires, they can increase the number of general members back to the original amount (or above) by either calling an SGM or using the process outlined in section 8.8.