### PR TITLE
Grant Life Membership to Taylor Manderson

### DIFF
--- a/life_members.md
+++ b/life_members.md
@@ -2,3 +2,4 @@
 
 - Dr. Joel Fenwick (2019 AGM, 8th Oct)
 - Nicholas Lambourne (2020 AGM, 6th Oct)
+- Taylor Manderson (2023 AGM, 5th Oct)


### PR DESCRIPTION
I am proposing a special resolution to grant life membership for UQCS to Taylor Manderson. I believe this is long overdue.
Taylor has met what I believe are the two conditions necessary for life membership: a) outstanding contributions to the society while a student at UQ; and b) outstanding contributions to the society following graduation.
For the former condition, the bulk of that was before my time, but Taylor served on the committee for four years, two of which as president. In that time, the UQCS Slack was instituted, which was the main communication platform for six years until 2021.
For the latter condition, Taylor has remained an active member of the UQCS community after graduating. She maintains a presence on the UQCS Discord, offering advice and anecdotes wherever needed. So far in 2023, she has sent 1027 messages on the UQCS Discord, about the same as the as the president, secretary, treasurer and committee account have sent combined\*. In addition, she has served as a judge multiple times at the UQCS Hackathon. For a long time after leaving committee, she helped maintain much of the UQCS technical infrastructure.
\* NB: I don't wish to encourage the spamming of the Discord, and life membership shouldn't be granted based only on Discord messages, but it does serve as a coarse metric.
I can't think of any member more deserving of life membership than Taylor.