### PR TITLE
Grant Life Membership to James Dearlove

### DIFF
--- a/life_members.md
+++ b/life_members.md
@@ -2,3 +2,4 @@
 
 - Dr. Joel Fenwick (2019 AGM, 8th Oct)
 - Nicholas Lambourne (2020 AGM, 6th Oct)
+- James Dearlove (2023 AGM, 5th Oct)


### PR DESCRIPTION
I had not realised this was a special resolution thing, had intended to catch them off guard at the AGM. Thanks to Sigma's mass updates for helping to realise this.

I can't speak to any specifics of Jimmy's contributions during his time in office as I only became a member of UQCS the year after his reign ended. Despite that, I could not imagine that helming the club off the back of the pandemic that shut down socialising as we knew it was any easy feat. I can however confidently say that despite no longer being a student or a UQCS exec, Jimmy's contributions are still not over and clear to see almost two years on.

Thus, I only think it is fair to submit :ghostJimmy: for life membership.