### PR TITLE
Remove constant from General Meeting Quorum

### DIFF
--- a/constitution.md
+++ b/constitution.md
@@ -244,7 +244,7 @@ the membership shall consider at a General Meeting whether that person's members
 
 ## 18 Quorum at General Meeting
 
-18.1 At any General Meeting, the number of members required to constitute a quorum shall be a number of members equal to the smallest integer greater than or equal to the square root of one hundred and twenty-five plus the number of financial members of the Society $\lceil \sqrt{125+n} \rceil$.
+18.1 At any General Meeting, the number of members required to constitute a quorum shall be a number of members equal to the smallest integer greater than or equal to the square root of the number of financial members of the Society ($\lceil \sqrt{n} \rceil$).
 
 ## 19 Notice of General Meeting
 


### PR DESCRIPTION
This change will remove the 125 constant from the quorum calculation.
In the past, the Union has been strict about the minimum possible quorum at the minimum club size (30 members), which was the origin of the 125 constant. The Union has become more relaxed in recent years. As such, the constant is no longer needed.
Last year, the society had 622 members at the time of the AGM. As such, the quorum was 28 members. Under this change, the quorum would be 25 members. This is a minor change, and if the club continues to grow, the effect will lessen further.
The main motivation for this change is to simplify the clause, especially when explained orally.