### PR TITLE
Add two week membership requirement for voting at general meetings (and other minor changes)

### DIFF
--- a/constitution.md
+++ b/constitution.md
@@ -257,13 +257,19 @@ the membership shall consider at a General Meeting whether that person's members
 ## 20 Procedure at General Meeting
 
 20.1 Unless otherwise provided by these rules, at every General Meeting:  
-* the President (or nominee for the meeting) shall preside as chairperson;  
+* the President (or nominee for the meeting) when the General Meeting commences shall preside as chairperson;  
 * if there is no President, or if the President is not present within fifteen (15) minutes after the time appointed for the holding of the meeting, or if the President has given notice of an inability to attend the meeting, or if the President is unwilling to act, or if there shall be an election for the position of President at the General Meeting, then the members present shall elect a member of the Society to be chairperson of the meeting;  
 * every question, matter or resolution arising at the General Meeting shall be decided by a vote, and shall pass with a simple majority;  
 * every resolution must be minuted;  
-* the minutes of the General Meeting shall be submitted to the Clubs and Societies Administration Officer within seven (7) days of the General Meeting;  
-* proxies that follow the University of Queensland Union regulations will be allowed; and  
-* proxies that follow a method authorised by the Management Committee, specified in the notice of the General Meeting, and ratified by the members of the Society at the General Meeting will be allowed.
+* the minutes of the General Meeting shall be submitted to the Clubs and Societies Administration Officer within seven (7) days of the General Meeting;
+
+20.2 Proxy voting on behalf of an absent member will be allowed at a General Meeting if:
+* the proxy follows the University of Queensland Union regulations; or  
+* the proxy follows a method authorised by the Management Committee, specified in the notice of the General Meeting, and ratified by the members of the Society at the General Meeting.
+
+20.3 No person can hold more than two (2) proxy votes at any General Meeting.
+
+20.4 A person may only participate in a General Meeting if they have been a member of the Society for at least fourteen (14) days at the time of a General Meeting.
 
 ## 21 Alteration of Rules
 
@@ -323,4 +329,4 @@ the membership shall consider at a General Meeting whether that person's members
 
 ---
 
-This constitution is enacted on this 8th day of October, 2019.
+This constitution is enacted on this 5th day of October, 2023.


### PR DESCRIPTION
This change will require people to be members of UQCS for two weeks before a general meeting in order to vote (or otherwise participate, which largely means running for election or moving motions). This adds a small hurdle to prevent stacking at an election. While stacking hasn't been a problem for UQCS in the past, it can suddenly become a major problem, so it's better to guard against it preventively. The notice period for a general meeting is two weeks, so having the same length for this means that the requirement isn't overly odious. The side benefit is that quorum will be fixed two weeks out, and won't suddenly increase moments before the AGM commences.

Also includes a change to the proxy clauses, to make the section flow better, and to limit proxies to two per member, another anti-stacking measure. The Chair clause has been clarified to reflect how the AGMs actually run, with the outgoing president chairing the AGM even after the election of a new president.