### PR TITLE
Add in clause for removing improperly elected committee member

### DIFF
--- a/constitution.md
+++ b/constitution.md
@@ -140,7 +140,11 @@ the management committee shall consider whether the member's membership shall be
 
 9.2 The Secretary may resign in the same manner as any other member of the Management Committee, with the exception of written notice shall instead be given to the President.
 
-9.3 If a member of the Management Committee:
+9.3 If a member of the Management Committee is found to have been improperly elected, they shall be removed from the Management Committee at such a time that the Secretary is made aware of them being improperly elected. However, any actions taken my the member of the Management Committee up until this time shall be treated as valid.
+
+9.4 The Secretary may be removed in the same manner as any other member of the Management Committee, with the exception that the time at which they are removed shall instead be the time that the President is made aware of them being improperly elected.
+
+9.5 If a member of the Management Committee:
 * fails to comply with any of the provisions of the Constitution;  
 * has membership fees in arrears;  
 * violates the Society's Code of Conduct;  
@@ -148,9 +152,9 @@ the management committee shall consider whether the member's membership shall be
 
 the membership shall consider at a General Meeting whether that person's membership of the Management Committee shall be terminated.
 
-9.4 That person concerned shall be given a full and fair opportunity to explain matters at the General Meeting. The question of removal shall be determined by a vote of sixty percent (60%) majority of the members present at the General Meeting and must be endorsed by the Clubs and Societies committee.
+9.6 That person concerned shall be given a full and fair opportunity to explain matters at the General Meeting. The question of removal shall be determined by a vote of sixty percent (60%) majority of the members present at the General Meeting and must be endorsed by the Clubs and Societies committee.
 
-9.5 There is no right of appeal against a member's removal from the Management Committee under this section.
+9.7 There is no right of appeal against a member's removal from the Management Committee under this section.
 
 ## 10 Vacancies on Management Committee
 

--- a/constitution.md
+++ b/constitution.md
@@ -140,7 +140,7 @@ the management committee shall consider whether the member's membership shall be
 
 9.2 The Secretary may resign in the same manner as any other member of the Management Committee, with the exception of written notice shall instead be given to the President.
 
-9.3 If a member of the Management Committee is found to have been improperly elected, they shall be removed from the Management Committee at such a time that the Secretary is made aware of them being improperly elected. However, any actions taken my the member of the Management Committee up until this time shall be treated as valid.
+9.3 If a member of the Management Committee is found to have been improperly elected, they shall be removed from the Management Committee at such a time that the Secretary is made aware of them being improperly elected. However, any actions taken by the member of the Management Committee up until this time shall be treated as valid.
 
 9.4 The Secretary may be removed in the same manner as any other member of the Management Committee, with the exception that the time at which they are removed shall instead be the time that the President is made aware of them being improperly elected.
 


### PR DESCRIPTION
Following the AGM last night, there was a brief moment of panic between @LimaoC and me that arose because it appeared that somebody who was elected wasn't actually a financial member of the society. This was resolved when it turned out that at least two people share a name.
With that said, the constitution doesn't currently specify how to handle this sort of situation, and this was going to be my suggestion for how to handle last night's situation, had it not been resolved so neatly. I'm making this proposal to formalise the handling of similar (hopefully rare) situations in the future.
If the committee member is an officer, then the role becomes a casual vacancy to be filled by the committee however they wish. If the committee member is a general member, then the role gets dissolved, and the committee shrinks by one, though there is a provision for the committee to create a new general committee position. For the non-financial member case, then the committee could reinstate them one way or another after they have become a financial member.
The second sentence means that anything they removed member did while on committee is still treated as valid, and so the committee won't have to go back through every decision and see if the removed member's vote would have affected anything. It also prevents a situation along the lines of president buys one billion metric dollars worth of stickers for the society -> treasurer reimburses them -> treasurer is found to have been improperly elected -> president is arrested for embezzlement.