### PR TITLE
Create Annotated Standard Annual General Meeting Agenda

### DIFF
--- a/annotated_standard_annual_general_meeting_agenda.md
+++ b/annotated_standard_annual_general_meeting_agenda.md
@@ -1,0 +1,84 @@
+# Annotated Standard Annual General Meeting Agenda
+## Agenda
+1. Opening
+2. Credentials
+    1. Attendee list
+    2. Check memberships
+    3. Quorum
+    4. Assign proxies
+    5. Others present
+3. Previous Minutes
+    - Ensure attendees have read the previous minutes
+    1. Ask for corrections (motion & vote)
+    2. Confirm (motion & vote)
+4. Matters Arising
+    1. Anything that remains to be dealt with from the previous meeting
+        - Tabled motions[^1]
+        - Unanswered questions on notice
+5. Officers' Reports
+    1. Present each report
+    - Treasurer also presents audit
+    2. Questions specifically about the report
+    - Questions that cannot be immediately answered with the information on hand should be taken on notice, and answered at the next meeting
+    3. Accept (motion & vote)
+    - Any missing reports (and officers) should be noted as "not provided"
+6. Questions for the Committee
+    - General questions to any member(s) of the committee
+7. Elections
+    1. Appoint a returning officer (motion & vote)
+        - Returning officer can at any time appoint assistant returning officers by consensus (usually for help counting general committee votes)
+    2. Dissolve the outgoing committee (motion & vote)
+    3. Description of election process
+        - This section
+        - Voting methods
+    5. Determine officer roles of the new committee (motion & vote)
+        - Order of creation matters
+    6. Determine number of general positions of the new committee (motion & vote)
+    7. Election of president
+        1. Description of role
+        2. Announce received nominations
+        3. Withdrawal of nominations
+        4. Nominations from the floor
+        5. Close of nominations
+        6. Candidate speeches
+        7. Secret balloting
+        8. Ballot counting
+        9. Announcement of result
+    8. Election of secretary
+        - Same process as president
+    9. Election of treasurer
+        - Same process as president
+    10. Election of minor officers
+        - One at a time
+        - Same order as they were created in
+        - Same process as president for each
+    11. Election of general committee
+        - Same process as president
+    12. Description of process of contesting election results
+    13. Return chair
+8. Business that has been proposed
+    - Usually any special resolutions
+    1. Mover speaks for the motion
+    2. Others speak on the motion
+    3. Ideally alternate speakers for and against
+    4. Vote
+    - Try to ensure neutral, clarifying questions have priority over speaking on the motion
+9. General Business
+    - Anything any member wishes to raise
+    - Motions similar to Business that has been proposed
+10. Closing
+## Voting
+Depending on the motion in question, the chair can conduct a vote in several ways:
+- Consensus vote: For minor and uncontroversial matters, the chair can simply ask "any objections". If there are none, then the motion is taken as passed.
+- Voice vote: The chair can call for those in favour. If the votes seem like a vast majority, then the chair should call for a perfunctory vote of those against. The chair can then state something along the lines of "I think the ayes have it". A member can object to this and force a counted vote. If the votes seem equal after calling for the against votes, then the chair should conduct a counted vote. If the votes in favour seem like a vast minority, then the chair can instead state "I think the nays have it" after the votes against.
+- Counted vote: The chair should call for those in favour, count them and announce the number, then call for the votes against, count them and announce the number, and determine the outcome based on the counts.
+- Secret ballot: Elections must be a secret ballot. A member can request any other vote to be a secret ballot. This should be used sparingly.
+## Procedural Motions
+These motions relate the the meeting itself, and can generally interrupt normal motions. They must be voted on, but usually not debated. There are others, but they are unlikely to be needed by UQCS
+- Put the motion: End debate of the current/main motion and proceed to vote on it, used if a member thinks that further debate in unnecessary. First, the procedural motion is voted on. If it passes, then the main motion is voted on.
+- Table the motion: Delay the discussion and voting of the current motion until the next meeting.
+- Adjourn the meeting: suspend the meeting for a short duration of time (i.e. measurable in minutes).
+- Close the meeting: close the meeting.
+- Dissent in the chair: if a member believes that the chair has erred in their duties, they may raise dissent to debate this. This should be used sparingly.
+ 
+[^1]: A procedural motion may be moved to consider any tabled motions at the start of Business Proposed

--- a/annotated_standard_annual_general_meeting_agenda.md
+++ b/annotated_standard_annual_general_meeting_agenda.md
@@ -33,7 +33,9 @@
         - Voting methods
     5. Determine officer roles of the new committee (motion & vote)
         - Order of creation matters
+        - Total committee positions must be less than half of AGM quorum
     6. Determine number of general positions of the new committee (motion & vote)
+        - Total committee positions must be less than half of AGM quorum
     7. Election of president
         1. Description of role
         2. Announce received nominations


### PR DESCRIPTION
Annual General Meetings only happen once a year [citation needed], and tend to be chaired by a different person each time. As such, this has the eminently reasonable consequence of the chair being unfamiliar with the process. As such, I thought it might be a good idea to create a standard agenda, annotated with various notes, to assist the chairs in the future.