### PR TITLE
Remove committee member

### DIFF
--- a/constitution.md
+++ b/constitution.md
@@ -150,7 +150,7 @@ the membership shall consider at a General Meeting whether that person's members
 
 9.4 That person concerned shall be given a full and fair opportunity to explain matters at the General Meeting. The question of removal shall be determined by a vote of sixty percent (60%) majority of the members present at the General Meeting and must be endorsed by the Clubs and Societies committee.
 
-9.5 If a member of the Management Committee fails to attend any meetings of the Management Committee for three (3) consecutive calendar months in which at least one (1) quorate meeting was held in each calendar month, that person's membership of the Management Committee shall be terminated.
+9.5 Should any member of the Management Committee fail to attend a minimum of $\min(1, \lfloor(\frac{x}{3})\rfloor)$ meeting(s) during a standard academic month—defined as any calendar month in which all weeks coincide with either Semester 1 or Semester 2 study periods—and without receiving a reasonable pardon from the full T3 council, that person's membership of the Management Committee shall be terminated.
 
 9.6 There is no right of appeal against a member's removal from the Management Committee under this section.
 


### PR DESCRIPTION
More explicit than the three months rule, I wanted to shorten it because a committee member can easily join a meeting for let's say 5 minutes and they would be exempt from this "rule".

We had several people kicked from the committee due to this rule and I strongly believe that 3 months is simply too long. 