### PR TITLE
Let me cook v2

### DIFF
--- a/constitution.md
+++ b/constitution.md
@@ -150,6 +150,8 @@ the membership shall consider at a General Meeting whether that person's members
 
 9.4 That person concerned shall be given a full and fair opportunity to explain matters at the General Meeting. The question of removal shall be determined by a vote of sixty percent (60%) majority of the members present at the General Meeting and must be endorsed by the Clubs and Societies committee.
 
+9.5 If 4 or more members of the Management Committee is terminated or removed, a General Meeting must be called.
+
 9.5 If a member of the Management Committee fails to attend any meetings of the Management Committee for three (3) consecutive calendar months in which at least one (1) quorate meeting was held in each calendar month, that person's membership of the Management Committee shall be terminated.
 
 9.6 There is no right of appeal against a member's removal from the Management Committee under this section.


### PR DESCRIPTION
I propose that only positions of general committee members if terminated or resign to be filled without an SGM.

Looking at other societies similar in size to UQCS, they only nominate their t3 and officer (or its equivalent) at the SGM/AGM and bring in their "general committee" either through interviews or google forms, this has also been brought to my attend by members as they have found the SGM/AGM shit posty and long. Multiple potentially great candidates have had to leave the SGM/AGM as they cannot reach the section to give their speeches for a general committee member position last few SGM/AGMs have gone way to long (last year was 3-4 hours). 
**However I list my concerns:** 
- Nepotism could be involved when choosing general committee positions
- Time consuming (to conduct interviews) 

This constitution will allow members of our society that does resign/terminate to be filled through a more informal process (e.g. Google Forms to gather potential candidates, committee then voting on that).
- This reduces nepotism (less) and does not pressures the t3 + t6 equivalence to vote people in (other societies do this I believe).
- Time efficient
This also naturally allows officer positions who (actually) become vacant to be filled by a general committee member as opposed to when a general committee member resigns or is terminated, a vacant spot isn't actually created but the workload of the committee remains the same. My concerns with nepotism with this constitution still lingers, hence I have added another constitution where if 4 of the management committee resigns (officer and general in this case) , an SGM must be called as something in the society might be evidentially (or not) be going wrong (suggested by Iain - Thanks). 

This constitution would allow an SGM to be called when required as 4 out of the 6 years, an SGM has been called. I would also like to comment that although an SGM wasn't called in 2023, the committee was actually ran by only 11 people (if I recall correctly). Although the 2023 committee stayed afloat due to Limao and Rachel been extremely productive and organised, this may be not be the case in future management committees. In 2024, we had someone resign day of AGM as they applied as a joke (multiple roles), we have also had certain individuals showing up to SGMs/AGMs nominated themselves for "troll" positions even after multiple warnings. We also had 3 resign/terminate due to inactivity and an SGM was then called again to bring on another 3 which also another 2 was terminated due to inactivity.

Running a committee is already extremely difficult, with less people onboard we struggle more. I hope the rest of the society can see the angle committee is coming from and the conversation I have opened up, I wish to see what people have to say about this. 

Thanks, 
Jackie