### PR TITLE
Draft Minutes Availability

### DIFF
--- a/constitution.md
+++ b/constitution.md
@@ -265,7 +265,8 @@ the membership shall consider at a General Meeting whether that person's members
 * if there is no President, or if the President is not present within fifteen (15) minutes after the time appointed for the holding of the meeting, or if the President has given notice of an inability to attend the meeting, or if the President is unwilling to act, or if there shall be an election for the position of President at the General Meeting, then the members present shall elect a member of the Society to be chairperson of the meeting;  
 * every question, matter or resolution arising at the General Meeting shall be decided by a vote, and shall pass with a simple majority;  
 * every resolution must be minuted;  
-* the minutes of the General Meeting shall be submitted to the Clubs and Societies Administration Officer within seven (7) days of the General Meeting;
+* a draft of the minutes of the General Meeting shall be submitted to the Clubs and Societies Administration Officer within seven (7) days of the General Meeting; and
+* a draft of the minutes of the General Meeting shall be made available to the Members of the Society within seven (7) days of the General Meeting.
 
 20.2 Proxy voting on behalf of an absent member will be allowed at a General Meeting if:
 * the proxy follows the University of Queensland Union regulations; or  


### PR DESCRIPTION
Memories fades over time, and so it is important that a draft of the meeting minutes are made available for review as soon as possible after a general meeting. Five months is far too long to expect members to be able to recollect the details of the meeting if they wish to suggest corrections. The minutes must already be submitted to the Union within seven days, so the only burden this adds is to publish them so that the members can view them (by convention, and for ease of submitting corrections, here on GitHub). These minutes are labelled as "draft minutes" in this amendment, to make it clear that they will not have been confirmed yet, as that will happen at the next AGM.