### PR TITLE
Grant Life Membership to Bradley Stone

### DIFF
--- a/life_members.md
+++ b/life_members.md
@@ -4,4 +4,4 @@
 - Nicholas Lambourne (2020 AGM, 6th Oct)
 - Taylor Manderson (2023 AGM, 5th Oct)
 - James Dearlove (2023 AGM, 5th Oct)
-- Bradley Stone (insert whichever meeting this happens at)
+- Bradley Stone (2025 SGM, 8th May)

--- a/life_members.md
+++ b/life_members.md
@@ -4,3 +4,4 @@
 - Nicholas Lambourne (2020 AGM, 6th Oct)
 - Taylor Manderson (2023 AGM, 5th Oct)
 - James Dearlove (2023 AGM, 5th Oct)
+- Bradley Stone (insert whichever meeting this happens at)


### PR DESCRIPTION
In the spirit of an impending SGM with constitutional updates, I have been reviewing those proposed updates and past minutes for those that may have previously been discussed. With this has become an apparent consistency that should be recognised. See the following excerpts from past General Meeting minutes:

> Isaac Beh nominated Bradley Stone for Returning Officer, Jackie Chang seconded. Bradley Stone accepted. No other nominations were made from the floor. Bradley Stone was appointed as as the Returning Officer.
- 2024 AGM

> Bradley Stone to be appointed as returning officer. Iain Jenson moved, Isaac seconded
> 
> The motion passed with 41 Yea votes, 0 Nay votes and no objections.
- 2024 SGM

> The Chair nominated Bradley Stone for Returning Officer, Isaac Beh seconded. Bradley Stone accepted. No other nominations were made from the floor. Bradley Stone was appointed as the Returning Officer.
- 2023 AGM

> The Chair nominated Bradley Stone for Returning Officer, Jay Hunter seconded. Bradley Stone accepted. No other nominations were made from the floor. Bradley Stone was appointed as the Returning Officer.
- 2022 AGM

> Bradley Stone to be appointed as returning officer. Tom Malcolm moved, Andrew Brown seconded.
> 
> The motion passed with 33 Yea votes, 0 Nay votes and no objections.
- 2022 SGM

> James Dearlove nominated Bradley Stone, Matthew Low seconded. Bradley accepted. No other nominations from the floor, Bradley was appointed as the returning officer.
- 2021 AGM

> Bradley Stone to be appointed as returning officer.
> Madhav Mishra moved, Sannidhi Bosamia seconded.
- 2020 AGM

Of course Returning Officer in and of itself is not the full picture that should qualify someone for the honour on its own. I also include similar reasoning to that I gave for Jimmy in #50 where Bradley was involved as an executive prior to my membership of UQCS and have come to see him as quite a fixture of the society in the years since I joined in 2022. Additionally, as the De Facto 'Constitutional Clarifier', there is no doubt of the ongoing commitment to the society that should be warranted to earn the title of Life Member. Having spent numerous years in a T3 role with MARS, I also know that dedicating to numerous consecutive years in a society T3 is not a small feat, and so the multi-term stint as treasurer no doubt led to strong impacts.

Of course this is not a decision to be reviewed at the SGM in less than two days time (see the minimum 14 days of notice required for Special Resolutions), but I would say is fairly overdue and should be given its light at the next General Meeting for which it is appropriate (presumably the 2025 AGM).

And of course, :dont_forget_youre_here_forever: