### PR TITLE
Added specification to the durational membership requirement for GMs

### DIFF
--- a/constitution.md
+++ b/constitution.md
@@ -268,12 +268,13 @@ the membership shall consider at a General Meeting whether that person's members
 * the minutes of the General Meeting shall be submitted to the Clubs and Societies Administration Officer within seven (7) days of the General Meeting;
 
 20.2 Proxy voting on behalf of an absent member will be allowed at a General Meeting if:
-* the proxy follows the University of Queensland Union regulations; or  
-* the proxy follows a method authorised by the Management Committee, specified in the notice of the General Meeting, and ratified by the members of the Society at the General Meeting.
+* the proxy follows the University of Queensland Union regulations;
+* the proxy follows a method authorised by the Management Committee, specified in the notice of the General Meeting, and ratified by the members of the Society at the General Meeting; or
+* the absent member who proxies their vote would themselves hold voting rights at the General Meeting.
 
 20.3 No person can hold more than two (2) proxy votes at any General Meeting.
 
-20.4 A person may only participate in a General Meeting if they have been a member of the Society for at least fourteen (14) of the sixty (60) days immediately preceding the General Meeting.
+20.4 A person may only hold voting rights and be eligible to participate in a General Meeting if they have been a member of the Society for at least fourteen (14) of the sixty (60) days immediately preceding the General Meeting.
 
 ## 21 Alteration of Rules
 

--- a/constitution.md
+++ b/constitution.md
@@ -267,10 +267,9 @@ the membership shall consider at a General Meeting whether that person's members
 * every resolution must be minuted;  
 * the minutes of the General Meeting shall be submitted to the Clubs and Societies Administration Officer within seven (7) days of the General Meeting;
 
-20.2 Proxy voting on behalf of an absent member will be allowed at a General Meeting if:
-* the proxy follows the University of Queensland Union regulations;
-* the proxy follows a method authorised by the Management Committee, specified in the notice of the General Meeting, and ratified by the members of the Society at the General Meeting; or
-* the absent member who proxies their vote would themselves hold voting rights at the General Meeting.
+20.2 Proxy voting on behalf of an absent member will be allowed at a General Meeting if the absent member who proxies their vote would themselves hold voting rights at the General Meeting and:
+* the proxy follows the University of Queensland Union regulations; or
+* the proxy follows a method authorised by the Management Committee, specified in the notice of the General Meeting, and ratified by the members of the Society at the General Meeting.
 
 20.3 No person can hold more than two (2) proxy votes at any General Meeting.
 

--- a/constitution.md
+++ b/constitution.md
@@ -273,7 +273,7 @@ the membership shall consider at a General Meeting whether that person's members
 
 20.3 No person can hold more than two (2) proxy votes at any General Meeting.
 
-20.4 A person may only participate in a General Meeting if they have been a member of the Society for at least fourteen (14) days at the time of a General Meeting.
+20.4 A person may only participate in a General Meeting if they have been a member of the Society for at least fourteen (14) of the sixty (60) days immediately preceding the General Meeting.
 
 ## 21 Alteration of Rules
 


### PR DESCRIPTION
The current wording is non-specific and would technically include any member who has at any point held membership for a duration of at least 14 days. This would establish a time frame for which this should be true (to account for what I have been told was the initial intention to have been 14 contiguous days) and provides leeway for any continuing members who were slow to renew wishing to attend SGMs which may be held in the months of March and April following the lapsing of memberships.