### PR TITLE
Lower proxy vote limit to one per person

### DIFF
--- a/constitution.md
+++ b/constitution.md
@@ -271,7 +271,7 @@ the membership shall consider at a General Meeting whether that person's members
 * the proxy follows the University of Queensland Union regulations; or  
 * the proxy follows a method authorised by the Management Committee, specified in the notice of the General Meeting, and ratified by the members of the Society at the General Meeting.
 
-20.3 No person can hold more than two (2) proxy votes at any General Meeting.
+20.3 No person can hold more than one (1) proxy vote at any General Meeting.
 
 20.4 A person may only participate in a General Meeting if they have been a member of the Society for at least fourteen (14) days at the time of a General Meeting.
 


### PR DESCRIPTION
The purpose of a proxy vote is to allow a member who is legitimately unable to attend the meeting to still have a voice in the Society's democratic processes. The purpose of this amendment is to discourage a practice sometimes referred to as 'proxy stacking', where a candidate for an elected position arranges for as many proxy votes as possible to be held by members likely to support the candidate. While campaigning is inevitable in any democratic process, this practice (in its extreme form) turns elections into a contest of which candidate can harvest the largest number of proxies.
This PR explicitly aims to avoid disenfranchising members who are forced to use a proxy vote due a legitimate inability to attend the meeting. Given the fact that a person is not required to be a member in order to hold a proxy vote it is unlikely that a member would be left unable to find someone to hold their proxy (even with the lowered limit).

Although it isn't directly related to the content of this PR, members are also reminded of their ability to instruct the person holding their proxy vote on how to use it, i.e. a proxy vote doesn't have to simply double the voting power of the member who holds it.